### PR TITLE
Remove `inspect` from allowed methods

### DIFF
--- a/lib/safemode/blankslate.rb
+++ b/lib/safemode/blankslate.rb
@@ -1,7 +1,7 @@
 module Safemode
   class Blankslate
-    @@allow_instance_methods = ['class', 'inspect', 'methods', 'respond_to?', 'respond_to_missing?', 'to_s', 'instance_variable_get']
-    @@allow_class_methods    = ['methods', 'new', 'name', 'inspect', '<', 'ancestors', '=='] # < needed in Rails Object#subclasses_of
+    @@allow_instance_methods = ['class', 'methods', 'respond_to?', 'respond_to_missing?', 'to_s', 'instance_variable_get']
+    @@allow_class_methods    = ['methods', 'new', 'name', '<', 'ancestors', '=='] # < needed in Rails Object#subclasses_of
 
     silently { undef_methods(*instance_methods.map(&:to_s) - @@allow_instance_methods) }
     class << self

--- a/test/test_jail.rb
+++ b/test/test_jail.rb
@@ -19,7 +19,7 @@ class TestJail < Test::Unit::TestCase
   end
 
   def test_jail_instances_should_have_limited_methods
-    expected = ["class", "inspect", "method_missing", "methods", "respond_to?", "respond_to_missing?", "to_jail", "to_s", "instance_variable_get"]
+    expected = ["class", "method_missing", "methods", "respond_to?", "respond_to_missing?", "to_jail", "to_s", "instance_variable_get"]
     expected.delete('respond_to_missing?') if RUBY_VERSION > '1.9.3' # respond_to_missing? is private in rubies above 1.9.3
     objects.each do |object|
       assert_equal expected.sort, reject_pretty_methods(object.to_jail.methods.map(&:to_s).sort)
@@ -27,7 +27,7 @@ class TestJail < Test::Unit::TestCase
   end
 
   def test_jail_classes_should_have_limited_methods
-    expected = ["new", "methods", "name", "inherited", "method_added", "inspect",
+    expected = ["new", "methods", "name", "inherited", "method_added",
                 "allow", "allowed?", "allowed_methods", "init_allowed_methods",
                 "<", # < needed in Rails Object#subclasses_of
                 "ancestors", "==" # ancestors and == needed in Rails::Generator::Spec#lookup_class


### PR DESCRIPTION
The `inspect` method is pretty unsafe, as by default it includes
a lot of data from the object.