### PR TITLE
Fix Ruby 2.4.0 Integer Jail

### DIFF
--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -62,6 +62,11 @@ module Safemode
                     present? rec_merge! rehash reject reject! select shift
                     size sort store update value? values values_at),
 
+    'Integer'    => %w(abs blank? ceil chr coerce div divmod downto floor id2name
+                    integer? modulo modulo next nonzero? present? quo remainder
+                    round singleton_method_added size step succ times to_f to_i
+                    to_int to_s to_sym truncate upto zero?),
+
     'Range'      => %w(any? begin blank? each end exclude_end? first hash
                     include? include_without_range? last member? present?
                     step),


### PR DESCRIPTION
Ruby 2.4 defines Integer class shared for both Float and Fixnum objects. This is the trace from Foreman app which uses safe mode. It's is caused becase methods whitelist was not defined for this class.

```
Gem Load Error is: undefined method `+' for nil:NilClass
Backtrace for gem load error is:
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/safemode-1.2.4/lib/safemode/core_jails.rb:24:in `core_jail_methods'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/safemode-1.2.4/lib/safemode/core_jails.rb:5:in `block in define_core_jail_classes'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/safemode-1.2.4/lib/safemode/core_jails.rb:4:in `each'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/safemode-1.2.4/lib/safemode/core_jails.rb:4:in `define_core_jail_classes'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/safemode-1.2.4/lib/safemode.rb:39:in `<module:Safemode>'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/safemode-1.2.4/lib/safemode.rb:24:in `<top (required)>'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.0/lib/bundler/runtime.rb:91:in `require'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.0/lib/bundler/runtime.rb:91:in `block (2 levels) in require'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.0/lib/bundler/runtime.rb:86:in `each'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.0/lib/bundler/runtime.rb:86:in `block in require'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.0/lib/bundler/runtime.rb:75:in `each'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.0/lib/bundler/runtime.rb:75:in `require'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.0/lib/bundler.rb:107:in `require'
/home/ares/Projekty/Zdrojaky/foreman/config/application.rb:36:in `<top (required)>'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:78:in `require'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:78:in `block in server'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:75:in `tap'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:75:in `server'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-4.2.7.1/lib/rails/commands.rb:17:in `<top (required)>'
/home/ares/Projekty/Zdrojaky/foreman/bin/rails:9:in `require'
/home/ares/Projekty/Zdrojaky/foreman/bin/rails:9:in `<top (required)>'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/spring-1.7.2/lib/spring/client/rails.rb:28:in `load'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/spring-1.7.2/lib/spring/client/rails.rb:28:in `call'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/spring-1.7.2/lib/spring/client/command.rb:7:in `call'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/spring-1.7.2/lib/spring/client.rb:30:in `run'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/spring-1.7.2/bin/spring:49:in `<top (required)>'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/spring-1.7.2/lib/spring/binstub.rb:11:in `load'
/home/ares/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/spring-1.7.2/lib/spring/binstub.rb:11:in `<top (required)>'
/home/ares/Projekty/Zdrojaky/foreman/bin/spring:13:in `require'
/home/ares/Projekty/Zdrojaky/foreman/bin/spring:13:in `<top (required)>'
```