### PR TITLE
Permit access to String.new for Ruby 2.4 ERB compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem "bundler", "~> 1.0"
   gem "jeweler", ">= 0"
   gem "rcov", :platforms => :ruby_18
-  gem "simplecov", :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23]
-  gem "test-unit", :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23]
+  gem "simplecov", :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
+  gem "test-unit", :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem "rake"
 end

--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,10 @@ can do that by defining a Safemode::Jail class for your classes, like so:
 This will allow your template users to access the name method on your User 
 objects.
 
+Class methods can be whitelisted by calling `allow_class_method :foo` from
+within the Jail. Note that access to raw constants is not permitted, so the
+class is only accessible when returned by a method or passed into a template.
+
 For more details about the concepts behind Safemode please refer to the 
 following blog posts until a more comprehensive writeup is available:
 

--- a/lib/safemode.rb
+++ b/lib/safemode.rb
@@ -24,7 +24,7 @@ require 'safemode/scope'
 module Safemode
   class << self
     def jail(obj)
-      find_jail_class(obj.class).new obj
+      find_jail_class(obj.is_a?(Class) ? obj : obj.class).new obj
     end
     
     def find_jail_class(klass)

--- a/lib/safemode/blankslate.rb
+++ b/lib/safemode/blankslate.rb
@@ -10,24 +10,41 @@ module Safemode
       def method_added(name) end # ActiveSupport needs this
 
       def inherited(subclass)
-        subclass.init_allowed_methods(@allowed_methods)
+        subclass.init_allowed_methods(@allowed_instance_methods, @allowed_class_methods)
       end
 
-      def init_allowed_methods(allowed_methods)
-        @allowed_methods = allowed_methods
+      def init_allowed_methods(allowed_instance_methods, allowed_class_methods)
+        @allowed_instance_methods = allowed_instance_methods
+        @allowed_class_methods = allowed_class_methods
       end
 
-      def allowed_methods
-        @allowed_methods ||= []
+      def allowed_instance_methods
+        @allowed_instance_methods ||= []
+      end
+      alias_method :allowed_methods, :allowed_instance_methods
+
+      def allowed_class_methods
+        @allowed_class_methods ||= []
       end
 
-      def allow(*names)
-        @allowed_methods = allowed_methods + names.map{|name| name.to_s}
-        @allowed_methods.uniq!
+      def allow_instance_method(*names)
+        @allowed_instance_methods = allowed_instance_methods + names.map{|name| name.to_s}
+        @allowed_instance_methods.uniq!
+      end
+      alias_method :allow, :allow_instance_method
+
+      def allow_class_method(*names)
+        @allowed_class_methods = allowed_class_methods + names.map{|name| name.to_s}
+        @allowed_class_methods.uniq!
       end
 
-      def allowed?(name)
-        allowed_methods.include? name.to_s
+      def allowed_instance_method?(name)
+        allowed_instance_methods.include? name.to_s
+      end
+      alias_method :allowed?, :allowed_instance_method?
+
+      def allowed_class_method?(name)
+        allowed_class_methods.include? name.to_s
       end
     end
   end

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -14,7 +14,7 @@ module Safemode
     end
 
     def core_classes
-      klasses = [ Array, Bignum, Fixnum, Float, Hash, Range, String, Symbol, Time, NilClass, FalseClass, TrueClass ]
+      klasses = [ Array, Bignum, Class, Fixnum, Float, Hash, Range, String, Symbol, Time, NilClass, FalseClass, TrueClass ]
       klasses << Date if defined? Date
       klasses << DateTime if defined? DateTime
       klasses
@@ -45,6 +45,8 @@ module Safemode
                     integer? modulo next nonzero? present? quo remainder round
                     singleton_method_added size step succ times to_f to_i
                     to_int to_s truncate upto zero?),
+
+    'Class'      => %w(new),
 
     'Fixnum'     => %w(abs blank? ceil chr coerce div divmod downto floor id2name
                     integer? modulo modulo next nonzero? present? quo remainder

--- a/lib/safemode/jail.rb
+++ b/lib/safemode/jail.rb
@@ -13,8 +13,14 @@ module Safemode
     end
   
     def method_missing(method, *args, &block)
-      unless self.class.allowed?(method)
-        raise Safemode::NoMethodError.new(method, self.class.name, @source.class.name) 
+      if @source.is_a?(Class)
+        unless self.class.allowed_class_method?(method)
+          raise Safemode::NoMethodError.new(".#{method}", self.class.name, @source.name)
+        end
+      else
+        unless self.class.allowed_instance_method?(method)
+          raise Safemode::NoMethodError.new("##{method}", self.class.name, @source.class.name)
+        end
       end
       
       # As every call to an object in the eval'ed string will be jailed by the
@@ -31,7 +37,7 @@ module Safemode
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      self.class.allowed?(method_name)
+      self.class.allowed_instance_method?(method_name)
     end
   end
 end

--- a/test/test_erb_eval.rb
+++ b/test/test_erb_eval.rb
@@ -13,7 +13,7 @@ class TestERBEval < Test::Unit::TestCase
   def test_some_stuff_that_should_work
     ['"test".upcase', '10.succ', '10.times{}', '[1,2,3].each{|a| a + 1}',
       'true ? 1 : 0', 'a = 1', 'unless "a" == "b"; "false"; end',
-      'if "a" != "b"; "true"; end'].each do |code|
+      'if "a" != "b"; "true"; end', 'String.new'].each do |code|
       code = ERB.new("<%= #{code} %>").src
       assert_nothing_raised{ @box.eval code }
     end
@@ -61,7 +61,7 @@ class TestERBEval < Test::Unit::TestCase
     call.gsub!('"', '\\\\"')
     class_eval %Q(
       def test_calling_#{call.gsub(/[\W]/, '_')}_should_raise_no_method
-        assert_raise_no_method "#{call}"
+        assert_raise_no_method "#{call}", @assigns, @locals
       end
     )
   end
@@ -70,7 +70,7 @@ class TestERBEval < Test::Unit::TestCase
     call.gsub!('"', '\\\\"')
     class_eval %Q(
       def test_calling_#{call.gsub(/[\W]/, '_')}_should_raise_security
-        assert_raise_security "#{call}"
+        assert_raise_security "#{call}", @assigns, @locals
       end
     )
   end  

--- a/test/test_jail.rb
+++ b/test/test_jail.rb
@@ -4,10 +4,15 @@ class TestJail < Test::Unit::TestCase
   def setup
     @article = Article.new.to_jail
     @comment = @article.comments.first
+    @comment_class = Comment.to_jail
   end
 
-  def test_explicitly_allowed_methods_should_be_accessible
+  def test_explicitly_allowed_instance_methods_should_be_accessible
     assert_nothing_raised { @article.title }
+  end
+
+  def test_explicitly_allowed_class_methods_should_be_accessible
+    assert_nothing_raised { @comment_class.all(1) }
   end
 
   def test_jail_instance_methods_should_be_accessible
@@ -29,6 +34,8 @@ class TestJail < Test::Unit::TestCase
   def test_jail_classes_should_have_limited_methods
     expected = ["new", "methods", "name", "inherited", "method_added",
                 "allow", "allowed?", "allowed_methods", "init_allowed_methods",
+                "allow_instance_method", "allow_class_method", "allowed_instance_method?",
+                "allowed_class_method?", "allowed_instance_methods", "allowed_class_methods",
                 "<", # < needed in Rails Object#subclasses_of
                 "ancestors", "==" # ancestors and == needed in Rails::Generator::Spec#lookup_class
                ]
@@ -49,7 +56,7 @@ class TestJail < Test::Unit::TestCase
   private
 
   def objects
-    [[], {}, 1..2, "a", :a, Time.now, 1, 1.0, nil, false, true]
+    [[], {}, 1..2, "a", :a, Time.now, 1, 1.0, nil, false, true, Comment]
   end
 
   def reject_pretty_methods(methods)

--- a/test/test_safemode_eval.rb
+++ b/test/test_safemode_eval.rb
@@ -12,7 +12,7 @@ class TestSafemodeEval < Test::Unit::TestCase
   def test_some_stuff_that_should_work
     ['"test".upcase', '10.succ', '10.times{}', '[1,2,3].each{|a| a + 1}',
      'true ? 1 : 0', 'a = 1', 'if "a" != "b"; "true"; end',
-     'if "a" == "b"; "true"; end'].each do |code|
+     'if "a" == "b"; "true"; end', 'String.new'].each do |code|
       assert_nothing_raised{ @box.eval code }
     end
   end
@@ -88,7 +88,7 @@ class TestSafemodeEval < Test::Unit::TestCase
     call.gsub!('"', '\\\\"')
     class_eval %Q(
       def test_calling_#{call.gsub(/[\W]/, '_')}_should_raise_no_method
-        assert_raise_no_method "#{call}"
+        assert_raise_no_method "#{call}", @assigns, @locals
       end
     )
   end
@@ -97,7 +97,7 @@ class TestSafemodeEval < Test::Unit::TestCase
     call.gsub!('"', '\\\\"')
     class_eval %Q(
       def test_calling_#{call.gsub(/[\W]/, '_')}_should_raise_security
-        assert_raise_security "#{call}"
+        assert_raise_security "#{call}", @assigns, @locals
       end
     )
   end  


### PR DESCRIPTION
ruby/ruby@c55ad90 changed ERB to generate String.new instead of "" for
frozen string compatibility, meaning safemode now has to permit access
to the String constant and .new class method.

Existing test suite now passes on Ruby 2.4.0.

---

Split into a very broad change to permit access to the `String` constant and _all_ `.new` class methods, and then a refactoring to add an allowed list of class methods in jails to restrict access to only `String.new`.