### PR TITLE
Register Integer jail, not Bignum/Fixnum on Ruby 2.4+

### DIFF
--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -14,9 +14,15 @@ module Safemode
     end
 
     def core_classes
-      klasses = [ Array, Bignum, Fixnum, Float, Hash, Range, String, Symbol, Time, NilClass, FalseClass, TrueClass ]
+      klasses = [ Array, Float, Hash, Range, String, Symbol, Time, NilClass, FalseClass, TrueClass ]
       klasses << Date if defined? Date
       klasses << DateTime if defined? DateTime
+      if RUBY_VERSION >= '2.4.0'
+        klasses << Integer
+      else
+        klasses << Bignum
+        klasses << Fixnum
+      end
       klasses
     end
 


### PR DESCRIPTION
Prevents a deprecation warning from being triggered and ensures the
jail is registered against the modern class.