### PR TITLE
Sorted and rearranged core whitelists via generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,8 +63,6 @@ else
   end
 end
 
-task :default => :test
-
 require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
@@ -74,3 +72,126 @@ Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_files.include('README*')
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
+
+Rake::TestTask.new(:generate) do
+  $:.unshift File.join(File.dirname(__FILE__), "lib")
+  require "safemode"
+  default_methods = Safemode.class_variable_get("@@default_methods")
+  dangerous_methods = %w(
+  !~
+  =~
+  class
+  class_eval
+  clone
+  deep_clone
+  deep_dup
+  define_singleton_method
+  display
+  dup
+  enum_for
+  extend
+  gem
+  __id__
+  inspect
+  instance_eval
+  instance_exec
+  instance_of?
+  instance_variable_defined?
+  instance_variable_get
+  instance_variables
+  instance_variable_set
+  itself
+  marshal_dump
+  marshal_load
+  method
+  methods
+  object_id
+  pathmap
+  pathmap_explode
+  pathmap_partial
+  pathmap_replace
+  pp
+  prepend
+  private_methods
+  protected_methods
+  public_method
+  public_methods
+  public_send
+  remove_instance_variable
+  __send__
+  send
+  silently
+  singleton_class
+  singleton_method
+  singleton_method_added
+  singleton_methods
+  taint
+  tainted?
+  to_enum
+  trust
+  try
+  untaint
+  untrust
+  untrusted?
+  with_options
+  )
+  common = {}
+  additional_methods = {}
+  additional_methods["String"] = %w(
+  iseuc
+  isjis
+  issjis
+  isutf8
+  kconv
+  toeuc
+  tojis
+  tolocale
+  tosjis
+  toutf16
+  toutf32
+  toutf8
+  )
+
+  objects = [
+    Array.new,
+    1.0,
+    Hash.new,
+    (1..2),
+    String.new,
+    :symbol,
+    Time.new,
+    Date.new,
+    DateTime.new,
+    nil,
+    false,
+    true]
+  if RUBY_VERSION >= '2.4.0'
+    # append Bignum and Fixnum
+    objects << (2 ** 62)
+    objects << 1
+  else
+    # append just Integer
+    objects << 1
+  end
+  objects.each do |object|
+    puts "  '#{object.class}' => %w("
+    object.methods.sort.each do |method|
+      next if default_methods.include?(method.to_s) || dangerous_methods.include?(method.to_s)
+      common[method] = 0 unless common[method]
+      common[method] += 1
+      puts "    #{method}"
+    end
+    if additional_methods.has_key?(object.class.to_s)
+      puts "    # methods from other classes named as #{object.class}"
+      additional_methods[object.class.to_s].sort.each do |method|
+        puts "    #{method}"
+      end
+    end
+    puts "  ),"
+    common.each_pair do |method, count|
+      puts " # common method: #{method}" if count >= objects.count
+    end
+  end
+end
+
+task :default => :test

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -71,6 +71,7 @@ module Safemode
     equal?
     freeze
     frozen?
+    hash
     in?
     inspect
     is_a?
@@ -82,6 +83,7 @@ module Safemode
     presence
     present?
     respond_to?
+    tap
     then
     to_a
     to_jail
@@ -89,61 +91,120 @@ module Safemode
     to_param
     to_query
     to_s
+    yield_self
   )
 
   # whitelisted methods for core classes ... kind of arbitrary selection
   @@methods_whitelist = {
   'Array' => %w(
+    all?
     any?
+    append
     assoc
     at
-    blank?
+    bsearch
+    bsearch_index
+    chunk
+    chunk_while
+    clear
     collect
     collect!
+    collect_concat
+    combination
     compact
     compact!
     concat
+    count
+    cycle
     delete
     delete_at
     delete_if
+    detect
+    dig
+    drop
+    drop_while
     each
+    each_cons
+    each_entry
     each_index
+    each_slice
+    each_with_index
+    each_with_object
     empty?
+    entries
     fetch
     fill
+    find
+    find_all
+    find_index
     first
+    flat_map
     flatten
     flatten!
-    hash
+    grep
+    grep_v
+    group_by
     include?
     index
-    indexes
-    indices
     inject
     insert
     join
+    keep_if
     last
+    lazy
     length
     map
     map!
-    nitems
+    max
+    max_by
+    member?
+    min
+    min_by
+    minmax
+    minmax_by
+    none?
+    one?
+    pack
+    partition
+    permutation
     pop
-    present?
+    product
     push
     rassoc
+    reduce
     reject
     reject!
+    repeated_combination
+    repeated_permutation
+    replace
     reverse
     reverse!
     reverse_each
     rindex
+    rotate
+    rotate!
+    sample
     select
+    select!
     shift
+    shuffle
+    shuffle!
     size
     slice
     slice!
+    slice_after
+    slice_before
+    slice_when
     sort
     sort!
+    sort_by
+    sort_by!
+    sum
+    take
+    take_while
+    to_ary
+    to_h
+    to_set
     transpose
     uniq
     uniq!
@@ -153,137 +214,309 @@ module Safemode
   ),
   'Float' => %w(
     abs
-    blank?
+    abs2
+    angle
+    arg
+    between?
     ceil
+    clamp
     coerce
+    conj
+    conjugate
+    denominator
     div
     divmod
+    fdiv
     finite?
     floor
-    hash
+    i
+    imag
+    imaginary
     infinite?
     integer?
+    magnitude
     modulo
     nan?
+    negative?
+    next_float
     nonzero?
-    present?
+    numerator
+    phase
+    polar
+    positive?
+    prev_float
     quo
+    rationalize
+    real
+    real?
+    rect
+    rectangular
     remainder
     round
-    singleton_method_added
     step
+    to_c
     to_f
     to_i
     to_int
-    to_s
+    to_r
     truncate
     zero?
   ),
   'Hash' => %w(
+    all?
     any?
-    blank?
+    assoc
+    chunk
+    chunk_while
     clear
+    collect
+    collect_concat
+    compact
+    compact!
+    compare_by_identity
+    compare_by_identity?
+    count
+    cycle
+    default
+    default=
+    default_proc
+    default_proc=
     delete
     delete_if
+    detect
+    dig
+    drop
+    drop_while
     each
+    each_cons
+    each_entry
     each_key
     each_pair
+    each_slice
     each_value
+    each_with_index
+    each_with_object
     empty?
+    entries
     fetch
+    fetch_values
+    find
+    find_all
+    find_index
+    first
+    flat_map
+    flatten
+    grep
+    grep_v
+    group_by
     has_key?
     has_value?
     include?
     index
+    inject
     invert
+    keep_if
+    key
     key?
     keys
+    lazy
     length
+    map
+    max
+    max_by
     member?
     merge
     merge!
-    present?
-    rec_merge!
+    min
+    min_by
+    minmax
+    minmax_by
+    none?
+    one?
+    partition
+    rassoc
+    reduce
     rehash
     reject
     reject!
+    replace
+    reverse_each
     select
+    select!
     shift
     size
+    slice
+    slice_after
+    slice_before
+    slice_when
     sort
+    sort_by
     store
+    sum
+    take
+    take_while
+    to_h
+    to_hash
+    to_proc
+    to_set
+    transform_keys
+    transform_keys!
+    transform_values
+    transform_values!
+    uniq
     update
     value?
     values
     values_at
+    zip
   ),
   'Range' => %w(
+    all?
     any?
     begin
-    blank?
+    bsearch
+    chunk
+    chunk_while
+    collect
+    collect_concat
+    count
+    cover?
+    cycle
+    detect
+    drop
+    drop_while
     each
+    each_cons
+    each_entry
+    each_slice
+    each_with_index
+    each_with_object
     end
+    entries
     exclude_end?
+    find
+    find_all
+    find_index
     first
-    hash
+    flat_map
+    grep
+    grep_v
+    group_by
     include?
-    include_without_range?
+    inject
     last
+    lazy
+    map
+    max
+    max_by
     member?
-    present?
+    min
+    min_by
+    minmax
+    minmax_by
+    none?
+    one?
+    partition
+    reduce
+    reject
+    reverse_each
+    select
+    size
+    slice_after
+    slice_before
+    slice_when
+    sort
+    sort_by
     step
+    sum
+    take
+    take_while
+    to_h
+    to_set
+    uniq
+    zip
   ),
   'String' => %w(
-    blank?
+    ascii_only?
+    b
+    between?
+    bytes
+    bytesize
+    byteslice
     capitalize
     capitalize!
     casecmp
+    casecmp?
     center
+    chars
+    chomp
+    chomp!
+    chop
+    chop!
+    chr
+    clamp
+    clear
+    codepoints
     concat
     count
     crypt
     delete
     delete!
+    delete_prefix
+    delete_prefix!
+    delete_suffix
+    delete_suffix!
     downcase
     downcase!
     dump
     each_byte
+    each_char
+    each_codepoint
+    each_grapheme_cluster
     each_line
     empty?
+    encode
+    encode!
+    encoding
     end_with?
+    ext
     force_encoding
+    getbyte
+    grapheme_clusters
+    grep
     gsub
     gsub!
-    hash
     hex
-    chomp
-    chomp!
-    chop
-    chop!
     include?
     index
     insert
     intern
-    iseuc
-    issjis
-    isutf8
-    kconv
     length
+    lineno
+    lineno=
+    lines
     ljust
     lstrip
     lstrip!
     match
+    match?
     next
     next!
     oct
-    present?
+    ord
+    partition
+    replace
     reverse
     reverse!
     rindex
     rjust
+    rpartition
     rstrip
     rstrip!
     scan
+    scrub
+    scrub!
+    setbyte
     size
     slice
     slice!
@@ -300,67 +533,103 @@ module Safemode
     sum
     swapcase
     swapcase!
-    toeuc
+    to_c
     to_f
     to_i
-    tojis
-    tosjis
+    to_r
     to_str
     to_sym
-    toutf16
-    toutf8
-    to_xs
     tr
     tr!
     tr_s
     tr_s!
+    undump
+    unicode_normalize
+    unicode_normalize!
+    unicode_normalized?
+    unpack
+    unpack1
     upcase
     upcase!
     upto
+    valid_encoding?
+    # methods from other classes named as String
+    iseuc
+    isjis
+    issjis
+    isutf8
+    kconv
+    toeuc
+    tojis
+    tolocale
+    tosjis
+    toutf16
+    toutf32
+    toutf8
   ),
   'Symbol' => %w(
-    blank?
-    present?
-    to_i
-    to_int
+    between?
+    capitalize
+    casecmp
+    casecmp?
+    clamp
+    downcase
+    empty?
+    encoding
+    id2name
+    intern
+    length
+    match
+    match?
+    next
+    size
+    slice
+    succ
+    swapcase
+    to_proc
+    to_sym
+    upcase
   ),
   'Time' => %w(
     asctime
-    blank?
+    between?
+    clamp
     ctime
     day
     dst?
-    _dump
+    friday?
     getgm
     getlocal
     getutc
     gmt?
+    gmt_offset
     gmtime
     gmtoff
-    gmt_offset
-    hash
     hour
-    httpdate
     isdst
-    iso8601
     localtime
     mday
     min
-    minus_without_duration
     mon
+    monday?
     month
-    plus_without_duration
-    present?
-    rfc2822
-    rfc822
+    nsec
+    round
+    saturday?
     sec
     strftime
+    subsec
     succ
+    sunday?
+    thursday?
     to_date
     to_datetime
     to_f
-    to_formatted_s
     to_i
+    to_r
+    to_time
+    tuesday?
+    tv_nsec
     tv_sec
     tv_usec
     usec
@@ -368,7 +637,7 @@ module Safemode
     utc?
     utc_offset
     wday
-    xmlschema
+    wednesday?
     yday
     year
     zone
@@ -377,110 +646,208 @@ module Safemode
     ajd
     amjd
     asctime
-    blank?
+    between?
+    clamp
     ctime
     cwday
     cweek
     cwyear
     day
     day_fraction
-    default_inspect
     downto
     england
+    friday?
     gregorian
     gregorian?
-    hash
+    httpdate
+    iso8601
     italy
     jd
+    jisx0301
     julian
     julian?
     ld
     leap?
     mday
-    minus_without_duration
     mjd
     mon
+    monday?
     month
-    newsg
     new_start
     next
-    ns?
-    os?
-    plus_without_duration
-    present?
-    sg
+    next_day
+    next_month
+    next_year
+    prev_day
+    prev_month
+    prev_year
+    rfc2822
+    rfc3339
+    rfc822
+    saturday?
     start
     step
     strftime
     succ
+    sunday?
+    thursday?
+    to_date
+    to_datetime
+    to_time
+    tuesday?
     upto
     wday
+    wednesday?
+    xmlschema
     yday
     year
   ),
   'DateTime' => %w(
-    blank?
+    ajd
+    amjd
+    asctime
+    between?
+    clamp
+    ctime
+    cwday
+    cweek
+    cwyear
+    day
+    day_fraction
+    downto
+    england
+    friday?
+    gregorian
+    gregorian?
     hour
+    httpdate
+    iso8601
+    italy
+    jd
+    jisx0301
+    julian
+    julian?
+    ld
+    leap?
+    mday
     min
-    newof
+    minute
+    mjd
+    mon
+    monday?
+    month
     new_offset
-    of
+    new_start
+    next
+    next_day
+    next_month
+    next_year
     offset
-    present?
+    prev_day
+    prev_month
+    prev_year
+    rfc2822
+    rfc3339
+    rfc822
+    saturday?
     sec
     sec_fraction
+    second
+    second_fraction
+    start
+    step
     strftime
-    to_datetime_default_s
-    to_json
+    succ
+    sunday?
+    thursday?
+    to_date
+    to_datetime
+    to_time
+    tuesday?
+    upto
+    wday
+    wednesday?
+    xmlschema
+    yday
+    year
     zone
   ),
   'NilClass' => %w(
-    blank?
-    duplicable?
-    present?
+    rationalize
+    to_c
     to_f
+    to_h
     to_i
+    to_r
   ),
   'FalseClass' => %w(
-    blank?
-    duplicable?
-    present?
   ),
   'TrueClass' => %w(
-    blank?
-    duplicable?
-    present?
   ),
   'Integer' => %w(
     abs
-    blank?
+    abs2
+    allbits?
+    angle
+    anybits?
+    arg
+    between?
+    bit_length
     ceil
+    chr
+    clamp
     coerce
+    conj
+    conjugate
+    denominator
+    digits
     div
     divmod
     downto
+    even?
+    fdiv
+    finite?
     floor
-    chr
-    id2name
+    gcd
+    gcdlcm
+    i
+    imag
+    imaginary
+    infinite?
     integer?
+    lcm
+    magnitude
     modulo
-    modulo
+    negative?
     next
+    nobits?
     nonzero?
-    present?
+    numerator
+    odd?
+    ord
+    phase
+    polar
+    positive?
+    pow
+    pred
     quo
+    rationalize
+    real
+    real?
+    rect
+    rectangular
     remainder
     round
-    singleton_method_added
     size
     step
     succ
     times
+    to_bn
+    to_c
     to_f
     to_i
     to_int
-    to_s
-    to_sym
+    to_r
     truncate
     upto
     zero?

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -65,9 +65,12 @@ module Safemode
     ^
     |
     ~
+    acts_like?
+    blank?
     eql?
     equal?
     freeze
+    in?
     inspect
     is_a?
     kind_of?
@@ -75,9 +78,13 @@ module Safemode
     new
     nil?
     not
+    presence
+    present?
     to_a
     to_jail
     to_param
+    to_param
+    to_query
     to_s
   )
 

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -217,40 +217,6 @@ module Safemode
     values
     values_at
   ),
-  'Integer' => %w(
-    abs
-    blank?
-    ceil
-    coerce
-    div
-    divmod
-    downto
-    floor
-    chr
-    id2name
-    integer?
-    modulo
-    modulo
-    next
-    nonzero?
-    present?
-    quo
-    remainder
-    round
-    singleton_method_added
-    size
-    step
-    succ
-    times
-    to_f
-    to_i
-    to_int
-    to_s
-    to_sym
-    truncate
-    upto
-    zero?
-  ),
   'Range' => %w(
     any?
     begin
@@ -484,6 +450,40 @@ module Safemode
     blank?
     duplicable?
     present?
+  ),
+  'Integer' => %w(
+    abs
+    blank?
+    ceil
+    coerce
+    div
+    divmod
+    downto
+    floor
+    chr
+    id2name
+    integer?
+    modulo
+    modulo
+    next
+    nonzero?
+    present?
+    quo
+    remainder
+    round
+    singleton_method_added
+    size
+    step
+    succ
+    times
+    to_f
+    to_i
+    to_int
+    to_s
+    to_sym
+    truncate
+    upto
+    zero?
   ),
   # Bignum was unified with Integer in Ruby 2.4
   'Bignum' => %w(

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -70,6 +70,7 @@ module Safemode
     eql?
     equal?
     freeze
+    frozen?
     in?
     inspect
     is_a?
@@ -80,6 +81,8 @@ module Safemode
     not
     presence
     present?
+    respond_to?
+    then
     to_a
     to_jail
     to_param

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -45,82 +45,464 @@ module Safemode
 
   # whitelisted methods for core classes ... kind of arbitrary selection
   @@methods_whitelist = {
-    'Array'      => %w(any? assoc at blank? collect collect! compact compact!
-                    concat delete delete_at delete_if each each_index empty?
-                    fetch fill first flatten flatten! hash include? index
-                    indexes indices inject insert join last length map map!
-                    nitems pop push present? rassoc reject reject! reverse
-                    reverse! reverse_each rindex select shift size slice
-                    slice! sort sort! transpose uniq uniq! unshift values_at
-                    zip),
-
-    'Bignum'     => %w(abs blank? ceil chr coerce div divmod downto floor hash
-                    integer? modulo next nonzero? present? quo remainder round
-                    singleton_method_added size step succ times to_f to_i
-                    to_int to_s truncate upto zero?),
-
-    'Fixnum'     => %w(abs blank? ceil chr coerce div divmod downto floor id2name
-                    integer? modulo modulo next nonzero? present? quo remainder
-                    round singleton_method_added size step succ times to_f to_i
-                    to_int to_s to_sym truncate upto zero?),
-
-    'Float'      => %w(abs blank? ceil coerce div divmod finite? floor hash
-                    infinite? integer? modulo nan? nonzero? present? quo
-                    remainder round singleton_method_added step to_f to_i
-                    to_int to_s truncate zero?),
-
-    'Hash'       => %w(any? blank? clear delete delete_if each each_key
-                    each_pair each_value empty? fetch has_key? has_value?
-                    include? index invert key? keys length member? merge merge!
-                    present? rec_merge! rehash reject reject! select shift
-                    size sort store update value? values values_at),
-
-    'Integer'    => %w(abs blank? ceil chr coerce div divmod downto floor id2name
-                    integer? modulo modulo next nonzero? present? quo remainder
-                    round singleton_method_added size step succ times to_f to_i
-                    to_int to_s to_sym truncate upto zero?),
-
-    'Range'      => %w(any? begin blank? each end exclude_end? first hash
-                    include? include_without_range? last member? present?
-                    step),
-
-    'String'     => %w(blank? capitalize capitalize! casecmp center chomp chomp!
-                    chop chop! concat count crypt delete delete! downcase
-                    downcase! dump each_byte each_line empty? end_with?
-                    force_encoding gsub gsub! hash hex include? index insert
-                    intern iseuc issjis isutf8 kconv length ljust lstrip
-                    lstrip! match next next! oct present? reverse reverse!
-                    rindex rjust rstrip rstrip! scan size slice slice! split
-                    squeeze squeeze! start_with? strip strip! sub sub! succ
-                    succ! sum swapcase swapcase! to_f to_i to_str to_sym to_xs
-                    toeuc tojis tosjis toutf16 toutf8 tr tr! tr_s tr_s! upcase
-                    upcase! upto),
-
-    'Symbol'     => %w(blank? present? to_i to_int),
-
-    'Time'       => %w(blank? _dump asctime ctime day dst? getgm getlocal
-                    getutc gmt? gmt_offset gmtime gmtoff hash hour httpdate
-                    isdst iso8601 localtime mday min minus_without_duration mon
-                    month plus_without_duration present? rfc2822 rfc822 sec
-                    strftime succ to_date to_datetime to_f to_i tv_sec tv_usec
-                    usec utc utc? utc_offset wday xmlschema yday year zone
-                    to_formatted_s),
-
-    'Date'       => %w(ajd amjd asctime blank? ctime cwday cweek cwyear day
-                    day_fraction default_inspect downto england gregorian
-                    gregorian? hash italy jd julian julian? ld leap? mday
-                    minus_without_duration mjd mon month new_start newsg next
-                    ns? os? plus_without_duration present? sg start step
-                    strftime succ upto wday yday year),
-
-    'DateTime'   => %w(blank? hour min new_offset newof of offset present? sec
-                    sec_fraction strftime to_datetime_default_s to_json zone),
-
-    'NilClass'   => %w(blank? duplicable? present? to_f to_i),
-
-    'FalseClass' => %w(blank? duplicable? present?),
-
-    'TrueClass'  => %w(blank? duplicable? present?)
+  'Array' => %w(
+    any?
+    assoc
+    at
+    blank?
+    collect
+    collect!
+    compact
+    compact!
+    concat
+    delete
+    delete_at
+    delete_if
+    each
+    each_index
+    empty?
+    fetch
+    fill
+    first
+    flatten
+    flatten!
+    hash
+    include?
+    index
+    indexes
+    indices
+    inject
+    insert
+    join
+    last
+    length
+    map
+    map!
+    nitems
+    pop
+    push
+    present?
+    rassoc
+    reject
+    reject!
+    reverse
+    reverse!
+    reverse_each
+    rindex
+    select
+    shift
+    size
+    slice
+    slice!
+    sort
+    sort!
+    transpose
+    uniq
+    uniq!
+    unshift
+    values_at
+    zip
+  ),
+  'Bignum' => %w(
+    abs
+    blank?
+    ceil
+    chr
+    coerce
+    div
+    divmod
+    downto
+    floor
+    hash
+    integer?
+    modulo
+    next
+    nonzero?
+    present?
+    quo
+    remainder
+    round
+    singleton_method_added
+    size
+    step
+    succ
+    times
+    to_f
+    to_i
+    to_int
+    to_s
+    truncate
+    upto
+    zero?
+  ),
+  'Fixnum' => %w(
+    abs
+    blank?
+    ceil
+    chr
+    coerce
+    div
+    divmod
+    downto
+    floor
+    id2name
+    integer?
+    modulo
+    modulo
+    next
+    nonzero?
+    present?
+    quo
+    remainder
+    round
+    singleton_method_added
+    size
+    step
+    succ
+    times
+    to_f
+    to_i
+    to_int
+    to_s
+    to_sym
+    truncate
+    upto
+    zero?
+  ),
+  'Float' => %w(
+    abs
+    blank?
+    ceil
+    coerce
+    div
+    divmod
+    finite?
+    floor
+    hash
+    infinite?
+    integer?
+    modulo
+    nan?
+    nonzero?
+    present?
+    quo
+    remainder
+    round
+    singleton_method_added
+    step
+    to_f
+    to_i
+    to_int
+    to_s
+    truncate
+    zero?
+  ),
+  'Hash' => %w(
+    any?
+    blank?
+    clear
+    delete
+    delete_if
+    each
+    each_key
+    each_pair
+    each_value
+    empty?
+    fetch
+    has_key?
+    has_value?
+    include?
+    index
+    invert
+    key?
+    keys
+    length
+    member?
+    merge
+    merge!
+    present?
+    rec_merge!
+    rehash
+    reject
+    reject!
+    select
+    shift
+    size
+    sort
+    store
+    update
+    value?
+    values
+    values_at
+  ),
+  'Integer' => %w(
+    abs
+    blank?
+    ceil
+    chr
+    coerce
+    div
+    divmod
+    downto
+    floor
+    id2name
+    integer?
+    modulo
+    modulo
+    next
+    nonzero?
+    present?
+    quo
+    remainder
+    round
+    singleton_method_added
+    size
+    step
+    succ
+    times
+    to_f
+    to_i
+    to_int
+    to_s
+    to_sym
+    truncate
+    upto
+    zero?
+  ),
+  'Range' => %w(
+    any?
+    begin
+    blank?
+    each
+    end
+    exclude_end?
+    first
+    hash
+    include?
+    include_without_range?
+    last
+    member?
+    present?
+    step
+  ),
+  'String' => %w(
+    blank?
+    capitalize
+    capitalize!
+    casecmp
+    center
+    chomp
+    chomp!
+    chop
+    chop!
+    concat
+    count
+    crypt
+    delete
+    delete!
+    downcase
+    downcase!
+    dump
+    each_byte
+    each_line
+    empty?
+    end_with?
+    force_encoding
+    gsub
+    gsub!
+    hash
+    hex
+    include?
+    index
+    insert
+    intern
+    iseuc
+    issjis
+    isutf8
+    kconv
+    length
+    ljust
+    lstrip
+    lstrip!
+    match
+    next
+    next!
+    oct
+    present?
+    reverse
+    reverse!
+    rindex
+    rjust
+    rstrip
+    rstrip!
+    scan
+    size
+    slice
+    slice!
+    split
+    squeeze
+    squeeze!
+    start_with?
+    strip
+    strip!
+    sub
+    sub!
+    succ
+    succ!
+    sum
+    swapcase
+    swapcase!
+    to_f
+    to_i
+    to_str
+    to_sym
+    to_xs
+    toeuc
+    tojis
+    tosjis
+    toutf16
+    toutf8
+    tr
+    tr!
+    tr_s
+    tr_s!
+    upcase
+    upcase!
+    upto
+  ),
+  'Symbol' => %w(
+    blank?
+    present?
+    to_i
+    to_int
+  ),
+  'Time' => %w(
+    blank?
+    _dump
+    asctime
+    ctime
+    day
+    dst?
+    getgm
+    getlocal
+    getutc
+    gmt?
+    gmt_offset
+    gmtime
+    gmtoff
+    hash
+    hour
+    httpdate
+    isdst
+    iso8601
+    localtime
+    mday
+    min
+    minus_without_duration
+    mon
+    month
+    plus_without_duration
+    present?
+    rfc2822
+    rfc822
+    sec
+    strftime
+    succ
+    to_date
+    to_datetime
+    to_f
+    to_i
+    tv_sec
+    tv_usec
+    usec
+    utc
+    utc?
+    utc_offset
+    wday
+    xmlschema
+    yday
+    year
+    zone
+    to_formatted_s
+  ),
+  'Date' => %w(
+    ajd
+    amjd
+    asctime
+    blank?
+    ctime
+    cwday
+    cweek
+    cwyear
+    day
+    day_fraction
+    default_inspect
+    downto
+    england
+    gregorian
+    gregorian?
+    hash
+    italy
+    jd
+    julian
+    julian?
+    ld
+    leap?
+    mday
+    minus_without_duration
+    mjd
+    mon
+    month
+    new_start
+    newsg
+    next
+    ns?
+    os?
+    plus_without_duration
+    present?
+    sg
+    start
+    step
+    strftime
+    succ
+    upto
+    wday
+    yday
+    year
+  ),
+  'DateTime' => %w(
+    blank?
+    hour
+    min
+    new_offset
+    newof
+    of
+    offset
+    present?
+    sec
+    sec_fraction
+    strftime
+    to_datetime_default_s
+    to_json
+    zone
+  ),
+  'NilClass' => %w(
+    blank?
+    duplicable?
+    present?
+    to_f
+    to_i
+  ),
+  'FalseClass' => %w(
+    blank?
+    duplicable?
+    present?
+  ),
+  'TrueClass' => %w(
+    blank?
+    duplicable?
+    present?
+  ),
   }
 
   # these class methods are allowed on all classes if they are present

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -39,9 +39,47 @@ module Safemode
   end
 
   # these methods are allowed in all classes if they are present
-  @@default_methods = %w( % & * ** + +@ - -@ / < << <= <=> ! != == === > >= >> ^ | ~
-                          eql? equal? new methods is_a? kind_of? nil?
-                          [] []= to_a to_jail to_s inspect to_param not freeze)
+  @@default_methods = %w(
+    !
+    !=
+    %
+    &
+    *
+    **
+    +
+    +@
+    -
+    -@
+    /
+    <
+    <<
+    <=
+    <=>
+    ==
+    ===
+    >
+    >=
+    >>
+    []
+    []=
+    ^
+    |
+    ~
+    eql?
+    equal?
+    freeze
+    inspect
+    is_a?
+    kind_of?
+    methods
+    new
+    nil?
+    not
+    to_a
+    to_jail
+    to_param
+    to_s
+  )
 
   # whitelisted methods for core classes ... kind of arbitrary selection
   @@methods_whitelist = {

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -141,72 +141,6 @@ module Safemode
     values_at
     zip
   ),
-  'Bignum' => %w(
-    abs
-    blank?
-    ceil
-    coerce
-    div
-    divmod
-    downto
-    floor
-    hash
-    chr
-    integer?
-    modulo
-    next
-    nonzero?
-    present?
-    quo
-    remainder
-    round
-    singleton_method_added
-    size
-    step
-    succ
-    times
-    to_f
-    to_i
-    to_int
-    to_s
-    truncate
-    upto
-    zero?
-  ),
-  'Fixnum' => %w(
-    abs
-    blank?
-    ceil
-    coerce
-    div
-    divmod
-    downto
-    floor
-    chr
-    id2name
-    integer?
-    modulo
-    modulo
-    next
-    nonzero?
-    present?
-    quo
-    remainder
-    round
-    singleton_method_added
-    size
-    step
-    succ
-    times
-    to_f
-    to_i
-    to_int
-    to_s
-    to_sym
-    truncate
-    upto
-    zero?
-  ),
   'Float' => %w(
     abs
     blank?
@@ -540,6 +474,74 @@ module Safemode
     blank?
     duplicable?
     present?
+  ),
+  # Bignum was unified with Integer in Ruby 2.4
+  'Bignum' => %w(
+    abs
+    blank?
+    ceil
+    coerce
+    div
+    divmod
+    downto
+    floor
+    hash
+    chr
+    integer?
+    modulo
+    next
+    nonzero?
+    present?
+    quo
+    remainder
+    round
+    singleton_method_added
+    size
+    step
+    succ
+    times
+    to_f
+    to_i
+    to_int
+    to_s
+    truncate
+    upto
+    zero?
+  ),
+  # Fixnum was unified with Integer in Ruby 2.4
+  'Fixnum' => %w(
+    abs
+    blank?
+    ceil
+    coerce
+    div
+    divmod
+    downto
+    floor
+    chr
+    id2name
+    integer?
+    modulo
+    modulo
+    next
+    nonzero?
+    present?
+    quo
+    remainder
+    round
+    singleton_method_added
+    size
+    step
+    succ
+    times
+    to_f
+    to_i
+    to_int
+    to_s
+    to_sym
+    truncate
+    upto
+    zero?
   ),
   }
 

--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -80,8 +80,8 @@ module Safemode
     map!
     nitems
     pop
-    push
     present?
+    push
     rassoc
     reject
     reject!
@@ -107,13 +107,13 @@ module Safemode
     abs
     blank?
     ceil
-    chr
     coerce
     div
     divmod
     downto
     floor
     hash
+    chr
     integer?
     modulo
     next
@@ -139,12 +139,12 @@ module Safemode
     abs
     blank?
     ceil
-    chr
     coerce
     div
     divmod
     downto
     floor
+    chr
     id2name
     integer?
     modulo
@@ -239,12 +239,12 @@ module Safemode
     abs
     blank?
     ceil
-    chr
     coerce
     div
     divmod
     downto
     floor
+    chr
     id2name
     integer?
     modulo
@@ -291,10 +291,6 @@ module Safemode
     capitalize!
     casecmp
     center
-    chomp
-    chomp!
-    chop
-    chop!
     concat
     count
     crypt
@@ -312,6 +308,10 @@ module Safemode
     gsub!
     hash
     hex
+    chomp
+    chomp!
+    chop
+    chop!
     include?
     index
     insert
@@ -352,16 +352,16 @@ module Safemode
     sum
     swapcase
     swapcase!
+    toeuc
     to_f
     to_i
-    to_str
-    to_sym
-    to_xs
-    toeuc
     tojis
     tosjis
+    to_str
+    to_sym
     toutf16
     toutf8
+    to_xs
     tr
     tr!
     tr_s
@@ -377,19 +377,19 @@ module Safemode
     to_int
   ),
   'Time' => %w(
-    blank?
-    _dump
     asctime
+    blank?
     ctime
     day
     dst?
+    _dump
     getgm
     getlocal
     getutc
     gmt?
-    gmt_offset
     gmtime
     gmtoff
+    gmt_offset
     hash
     hour
     httpdate
@@ -411,6 +411,7 @@ module Safemode
     to_date
     to_datetime
     to_f
+    to_formatted_s
     to_i
     tv_sec
     tv_usec
@@ -423,7 +424,6 @@ module Safemode
     yday
     year
     zone
-    to_formatted_s
   ),
   'Date' => %w(
     ajd
@@ -453,8 +453,8 @@ module Safemode
     mjd
     mon
     month
-    new_start
     newsg
+    new_start
     next
     ns?
     os?
@@ -474,8 +474,8 @@ module Safemode
     blank?
     hour
     min
-    new_offset
     newof
+    new_offset
     of
     offset
     present?


### PR DESCRIPTION
This PR rearanges whitelists in a reasonable way so it's easier to maintain. In several commits I break entries into multiple lines, sort them and rearrange them a bit with no changes performed. Then I add Ruby core and ActiveSupport core methods to the default_methods array. And finally, new rake task `generate` is added which generates whitelists and the last commit finally makes changes to the whitelists which need to be carefully reviewed.

The idea is to use generation approach for maintaining those whitelists, everytime there is a new Ruby release we can easily generate those. The rake task contains list of "dangerous" methods which I think should never go into Safemode therefore we do not need to bother with them during review.

I suggest to do review commit-by-commit as I was trying hard to make this as clear as possible. The last commit is the most important one - contains the script and the important diff - changes to the whitelists. I the review will go on, I will be amending only the last commit until we agree.

I will drop few comments now - these are still open questions.