### PR TITLE
allow to_sentence for array

### DIFF
--- a/lib/safemode/core_jails.rb
+++ b/lib/safemode/core_jails.rb
@@ -51,8 +51,8 @@ module Safemode
                     indexes indices inject insert join last length map map!
                     nitems pop push present? rassoc reject reject! reverse
                     reverse! reverse_each rindex select shift size slice
-                    slice! sort sort! transpose uniq uniq! unshift values_at
-                    zip),
+                    slice! sort sort! transpose to_sentence uniq uniq! unshift
+                    values_at zip),
 
     'Bignum'     => %w(abs blank? ceil chr coerce div divmod downto floor hash
                     integer? modulo next nonzero? present? quo remainder round


### PR DESCRIPTION
I can not see a problem in allowing to_sentence which creates only a nicer string than to_s. If you agree, I would be happy if this could be merged, so it is available for template writing in Foreman in the future.