### PR TITLE
Allow safemode to work with rails with zeitwerk

### DIFF
--- a/lib/safemode/blankslate.rb
+++ b/lib/safemode/blankslate.rb
@@ -1,7 +1,7 @@
 module Safemode
   class Blankslate
     @@allow_instance_methods = ['class', 'methods', 'respond_to?', 'respond_to_missing?', 'to_s', 'instance_variable_get']
-    @@allow_class_methods    = ['methods', 'new', 'name', '<', 'ancestors', '==']  # < needed in Rails Object#subclasses_of
+    @@allow_class_methods    = ['singleton_class?', 'methods', 'new', 'name', '<', 'ancestors', '==']  # < needed in Rails Object#subclasses_of
     if defined?(JRUBY_VERSION)
       # JRuby seems to silently fail to remove method_missing
       # (also see https://github.com/jruby/jruby/blob/9.1.7.0/core/src/main/java/org/jruby/RubyModule.java#L1109)

--- a/test/test_jail.rb
+++ b/test/test_jail.rb
@@ -36,7 +36,8 @@ class TestJail < Test::Unit::TestCase
                 "allow_instance_method", "allow_class_method", "allowed_instance_method?",
                 "allowed_class_method?", "allowed_instance_methods", "allowed_class_methods",
                 "<", # < needed in Rails Object#subclasses_of
-                "ancestors", "=="] # ancestors and == needed in Rails::Generator::Spec#lookup_class
+                "ancestors", "==", # ancestors and == needed in Rails::Generator::Spec#lookup_class
+                "singleton_class?" ]
 
     if defined?(JRUBY_VERSION)
       (expected << ['method_missing', 'singleton_method_undefined', 'singleton_method_added']).flatten!  # needed for running under jruby


### PR DESCRIPTION
Zeitwerk handles singleton and "regular" classes differently. For this to work,
it needs to be able to detect if a class is a singleton or not. This was not
exposed for jails, leading to error like NoMethodError: undefined method
`singleton_class?' for #<Class:0x0000556b7d6b69b0>.